### PR TITLE
Restrict whitespace definition (in skip token)

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -41,7 +41,7 @@
 //
 
 
-%skip   space           \s
+%skip   space           [\x20\x09\x0a\x0d]+
 
 %token  true            true
 %token  false           false


### PR DESCRIPTION
Need to be merged before https://github.com/hoaproject/Compiler/pull/27.

The [RFC4627] defines whitespace as follows (in Section 2. JSON Grammar):
> Insignificant whitespace is allowed before or after any of the six
> structural characters.
>
>     ws = *(
>               %x20 /              ; Space
>               %x09 /              ; Horizontal tab
>               %x0A /              ; Line feed or New line
>               %x0D                ; Carriage return
>           )

Previously, we used PCRE `\s` character type to represent whitespaces. However, it includes all horizontal spaces (which is correct) but also all vertical spaces (which is incorrect).

Now, we pick specific characters up to follow the RFC instead of using a character type from PCRE.

Also, we use `+` for performance reasons: A skip token is then a sequence of whitespaces, not just a single whitespace.

[RFC4627]: http://tools.ietf.org/html/rfc4627