### PR TITLE
Update the `string` rule to avoid skip tokens

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -46,10 +46,8 @@
 %token  true            true
 %token  false           false
 %token  null            null
-%token  quote_          "                             -> string
-%token  string:escaped  \\(["\\/bfnrt]|u[0-9a-fA-F]{4})
-%token  string:string   [^"\\]+
-%token  string:_quote   "                             -> default
+//%token  string          "([\x20-\x21\x23-\x5b-\x{10ffff}]|\\(["\\/bfnrt]|u[0-9a-fA-F]{4}))+"
+%token  string          "(\w|\\(["\\/bfnrt]))+"
 %token  brace_          {
 %token _brace           }
 %token  bracket_        \[
@@ -62,9 +60,7 @@ value:
     <true> | <false> | <null> | string() | object() | array() | number()
 
 string:
-    ::quote_::
     <string>
-    ::_quote::
 
 number:
     <number>

--- a/Grammar.pp
+++ b/Grammar.pp
@@ -41,7 +41,7 @@
 //
 
 
-%skip   space           \s
+%skip   space           [\x20\x09\x0a\x0d]+
 
 %token  true            true
 %token  false           false

--- a/Test/Unit/Soundness.php
+++ b/Test/Unit/Soundness.php
@@ -107,6 +107,13 @@ class Soundness extends Test\Unit\Suite
                 foreach ($sampler as $datum) {
                     $this
                         ->given(json_decode($datum))
+                        ->executeOnFailure(function () use ($datum) {
+                            if (true === function_exists('json_last_error_msg')) {
+                                echo
+                                    'Data:  ' . $datum, "\n",
+                                    'Error: ' . json_last_error_msg(), "\n";
+                            }
+                        })
                         ->when($error = json_last_error())
                         ->then
                             ->integer($error)


### PR DESCRIPTION
https://github.com/hoaproject/Json/pull/11 needs to be merged before.

We don't want skip tokens inside the strings. So now a string is defined by a single token instead of a sequence of tokens. So far, because we have some troubles with “Javascript UTF-8” strings, we disable UTF-8 temporarily.