### PR TITLE
Grammar: Object and array pairs are optional

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -65,10 +65,10 @@ number:
     <number>
 
 #object:
-    ::brace_:: pair() ( ::comma:: pair() )* ::_brace::
+    ::brace_:: ( pair() ( ::comma:: pair() )* )? ::_brace::
 
 #pair:
     string() ::colon:: value()
 
 #array:
-    ::bracket_:: value() ( ::comma:: value() )* ::_bracket::
+    ::bracket_:: ( value() ( ::comma:: value() )* )? ::_bracket::


### PR DESCRIPTION
Fix #15.

`{}` and `[]` are valid, even if empty.