### PR TITLE
Grammar: Support strict UTF-8 strings and be strict regarding numbers

### DIFF
--- a/Grammar.pp
+++ b/Grammar.pp
@@ -40,7 +40,8 @@
 //
 
 
-%pragma lexer.unicode   false
+%pragma lexer.unicode     false
+%pragma parser.lookahead  0
 
 %skip   space           [\x20\x09\x0a\x0d]+
 

--- a/Grammar.pp
+++ b/Grammar.pp
@@ -45,8 +45,7 @@
 %token  true            true
 %token  false           false
 %token  null            null
-//%token  string          "([\x20-\x21\x23-\x5b-\x{10ffff}]|\\(["\\/bfnrt]|u[0-9a-fA-F]{4}))+"
-%token  string          "(\w|\\(["\\/bfnrt]))+"
+%token  string          "([\x20\x21\x23-\x5b\x5d-\x7f]|[\xc2-\xdf][\x80-\xbf]|(\xe0[\xa0-\xbf][\x80-\xbf]|[\xe1-\xec][\x80-\xbf]{2}|\xed[\x80-\x9f][\x80-\xbf]{2}|[\xee-\xef][\x80-\xbf]{2})|(\xf0[\x90-\xbf][\x80-\xbf]{2}|[\xf1-\xf3][\x80-\xbf]{3}|\xf4[\x80-\x8f][\x80-\xbf]{2})|\\(["\\/bfnrt]))*"
 %token  brace_          {
 %token _brace           }
 %token  bracket_        \[

--- a/Grammar.pp
+++ b/Grammar.pp
@@ -33,7 +33,7 @@
 //
 // Grammar \Hoa\Json\Grammar.
 //
-// Provide grammar for JSON. Please, see <http://json.org> or RFC4627.
+// Provide grammar for JSON. Please, see <http://json.org>, RFC4627 or RFC7159.
 //
 // @copyright  Copyright © 2007-2016 Hoa community.
 // @license    New BSD License

--- a/Grammar.pp
+++ b/Grammar.pp
@@ -40,6 +40,8 @@
 //
 
 
+%pragma lexer.unicode   false
+
 %skip   space           [\x20\x09\x0a\x0d]+
 
 %token  true            true

--- a/Grammar.pp
+++ b/Grammar.pp
@@ -53,7 +53,7 @@
 %token _bracket         \]
 %token  colon           :
 %token  comma           ,
-%token  number          \-?(0|[1-9]\d*)(\.\d+)?([eE][\+\-]?\d+)?
+%token  number          \-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][\+\-]?[0-9]+)?
 
 value:
     <true> | <false> | <null> | string() | object() | array() | number()

--- a/Test/Integration/Soundness.php
+++ b/Test/Integration/Soundness.php
@@ -34,7 +34,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Hoa\Json\Test\Unit;
+namespace Hoa\Json\Test\Integration;
 
 use Hoa\Compiler as LUT;
 use Hoa\File;
@@ -44,14 +44,14 @@ use Hoa\Regex;
 use Hoa\Test;
 
 /**
- * Class \Hoa\Json\Test\Unit\Soundness.
+ * Class \Hoa\Json\Test\Integration\Soundness.
  *
  * Check soundness of the LL(k) compiler.
  *
  * @copyright  Copyright © 2007-2016 Hoa community
  * @license    New BSD License
  */
-class Soundness extends Test\Unit\Suite
+class Soundness extends Test\Integration\Suite
 {
     public function case_exaustive_json()
     {
@@ -130,7 +130,7 @@ class Soundness extends Test\Unit\Suite
     protected function getJSONCompiler()
     {
         return LUT\Llk::load(
-            new File\Read('hoa://Library/Json/Grammar.pp')
+            new File\Read(__DIR__ . '/../../Grammar.pp')
         );
     }
 

--- a/Test/Integration/Soundness.php
+++ b/Test/Integration/Soundness.php
@@ -130,7 +130,7 @@ class Soundness extends Test\Integration\Suite
     protected function getJSONCompiler()
     {
         return LUT\Llk::load(
-            new File\Read(__DIR__ . '/../../Grammar.pp')
+            new File\Read('hoa://Library/Json/Grammar.pp')
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name"       : "hoa/json",
     "description": "The Hoa\\Json library.",
     "type"       : "library",
-    "keywords"   : ["library", "json", "grammar"],
+    "keywords"   : ["library", "json", "grammar", "rfc4627", "rfc7159"],
     "homepage"   : "http://hoa-project.net/",
     "license"    : "BSD-3-Clause",
     "authors"    : [


### PR DESCRIPTION
Fix partially #17.

Regarding numbers:
> We avoid using `\d` instead of `[0-9]` because `\d` _might_ match other characters.

Regarding strings:
> UTF-8 is an issue with JSON, because we must handle surrogate pairs
> ([1], [2]). This patch implements UTF-8 not only for validating a datum
> but also for generating a datum. It means that we only generate valid
> UTF-8 strings and we only validate/recognize valid UTF-8 strings.
> 
> UTF-16 strings will follow in another patch.
> 
> Unfortunately, we decided to implement the whole string as a token, not
> as rules. This is unfortunate because grammar coverage algorithms in
> `Hoa\Compiler` applies only on rules, not on tokens. This is a potential
> optimisation.

[1]: http://tools.ietf.org/html/rfc7159#section-7
[2]: http://tools.ietf.org/html/rfc7159#section-8

Now we have 159876 assertions!